### PR TITLE
LightGraphs => Graphs, GeoData => Rasters, some changes to type names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.0.1"
 
 [deps]
 GeoData = "9b6fcbb8-86d6-11e9-1ce7-23a6bb139a78"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+GeoData = "0.5"
+Graphs = "1.4"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,13 @@ authors = ["Vincent A. Landau <vincent@csp-inc.org>"]
 version = "0.0.1"
 
 [deps]
-GeoData = "9b6fcbb8-86d6-11e9-1ce7-23a6bb139a78"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-GeoData = "0.5"
 Graphs = "1.4"
+Rasters = "0.1"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.circuitscape.org/SpatialGraphs.jl/latest) | [![Build Status](https://github.com/Circuitscape/SpatialGraphs.jl/workflows/CI/badge.svg)](https://github.com/Circuitscape/SpatialGraphs.jl/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/Circuitscape/SpatialGraphs.jl/branch/main/graph/badge.svg?token=67OX4UPWOL)](https://codecov.io/gh/Circuitscape/SpatialGraphs.jl)
 
 SpatialGraphs.jl introduces the `AbstractSpatialGraph`. `AbstractSpatialGraphs` 
-are a subtype of `LightGraphs.AbstractGraph`, and can be weighted or directed. 
-AbstractSpatialGraphs are AbstractGraphs, so methods from LightGraphs.jl work right
+are a subtype of `Graphs.AbstractGraph`, and can be weighted or directed. 
+AbstractSpatialGraphs are AbstractGraphs, so methods from Graphs.jl work right
 out of the box.
 
 `AbstractSpatialGraph`s themselves contain an `AbstractGraph` in addition to 

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ out of the box.
 `AbstractSpatialGraph`s themselves contain an `AbstractGraph` in addition to 
 metadata that details the spatial location of each vertex in the
 graph. At this time, only raster-based graph types have been developed (and 
-vertex locations are stored in a `GeoData.GeoArray`), but there are plans to 
+vertex locations are stored in a `Rasters.Raster`), but there are plans to 
 implement graph types for vector data as well.

--- a/docs/src/graphtypes.md
+++ b/docs/src/graphtypes.md
@@ -1,7 +1,7 @@
 # [Graph Types in SpatialGraphs.jl](@id graph_types)
 
 At this time, only raster-based graph types have been developed (and 
-vertex locations are stored in a `GeoData.GeoArray`), but there are plans to 
+vertex locations are stored in a `Rasters.Raster`), but there are plans to 
 eventually implement graph types for vector data as well.
 
 ## Abstract Types
@@ -14,7 +14,7 @@ AbstractSpatialGraph
 
 The `AbstractRasterGraph` type is a subtype of `AbstractSpatialGraph`. All
 `AbstractRasterGraph` subtypes contain a field called `vertex_raster`, which is 
-a `GeoData.GeoArray` that describes the spatial locations for the vertices in 
+a `Rasters.Raster` that describes the spatial locations for the vertices in 
 the graph. If your graph has 10 vertices, then the corresponding `vertex_raster` 
 must have 10 unique values, starting at 1 (which corresponds to the first vertex
 in the graph) and going up to 10 (which corresponds to the tenth vertex in the 

--- a/docs/src/graphtypes.md
+++ b/docs/src/graphtypes.md
@@ -12,7 +12,7 @@ an `AbstractGraph`.
 AbstractSpatialGraph
 ```
 
-The `AbstractRasterGraph` type is as subtype of `AbstractSpatialGraph`. All
+The `AbstractRasterGraph` type is a subtype of `AbstractSpatialGraph`. All
 `AbstractRasterGraph` subtypes contain a field called `vertex_raster`, which is 
 a `GeoData.GeoArray` that describes the spatial locations for the vertices in 
 the graph. If your graph has 10 vertices, then the corresponding `vertex_raster` 
@@ -30,8 +30,8 @@ SpatialGraphs.jl has raster graph types for undirected, directed, unweighted,
 and weighted graphs, each detailed below.
 
 ```@docs
-SimpleRasterGraph
-SimpleRasterDiGraph
+RasterGraph
+RasterDiGraph
 WeightedRasterGraph
 WeightedRasterDiGraph
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,10 @@
 # SpatialGraphs.jl
 
 SpatialGraphs.jl introduces the `AbstractSpatialGraph`. `AbstractSpatialGraphs` 
-are a subtype of `LightGraphs.AbstractGraph`, and can be weighted or directed.
+are a subtype of `Graphs.AbstractGraph`, and can be weighted or directed.
 SpatialGraphs.jl is useful for turning spatial data into graphs. This can be
 useful for landscape connectivity analysis, hydrology, and other spatial
 network processes. AbstractSpatialGraphs are AbstractGraphs, so methods from 
-LightGraphs.jl work right out of the box. Go to [Graph Types](@ref graph_types) 
+Graphs.jl work right out of the box. Go to [Graph Types](@ref graph_types) 
 for more details on the graph types implemented in this package.
 

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -7,7 +7,7 @@ data.
 
 ### Simple Graphs
 ```@docs
-simplerastergraph
+rastergraph
 make_simple_raster_graph
 ```
 

--- a/src/SpatialGraphs.jl
+++ b/src/SpatialGraphs.jl
@@ -1,6 +1,6 @@
 module SpatialGraphs
 
-using Graphs, SimpleWeightedGraphs, SparseArrays, GeoData
+using Graphs, SimpleWeightedGraphs, SparseArrays, Rasters
 
 include("structs.jl")
 include("graph_interface.jl")

--- a/src/SpatialGraphs.jl
+++ b/src/SpatialGraphs.jl
@@ -1,6 +1,6 @@
 module SpatialGraphs
 
-using LightGraphs, SimpleWeightedGraphs, SparseArrays, GeoData
+using Graphs, SimpleWeightedGraphs, SparseArrays, GeoData
 
 include("structs.jl")
 include("graph_interface.jl")
@@ -9,12 +9,12 @@ include("utils.jl")
 include("show.jl")
 
 ## Types and Structs
-export AbstractSpatialGraph, AbstractRasterGraph, SimpleRasterGraph,
-       SimpleRasterDiGraph, WeightedRasterGraph, WeightedRasterDiGraph
+export AbstractSpatialGraph, AbstractRasterGraph, RasterGraph,
+       RasterDiGraph, WeightedRasterGraph, WeightedRasterDiGraph
 
 ## Raster graph
 export make_weighted_raster_graph, weightedrastergraph,
-    make_simple_raster_graph, simplerastergraph
+    make_simple_raster_graph, rastergraph
 
 
 end # module

--- a/src/graph_interface.jl
+++ b/src/graph_interface.jl
@@ -1,6 +1,6 @@
-## Methods for the LightGraphs ad SimpleWeightedGraphs interfaces
-## With these methods defined, functions from LightGraphs should "just work"
-import LightGraphs: 
+## Methods for the Graphs ad SimpleWeightedGraphs interfaces
+## With these methods defined, functions from Graphs should "just work"
+import Graphs: 
     nv, ne, vertices, edges, eltype, edgetype, has_edge, has_vertex,
     inneighbors, outneighbors, is_directed, add_edge!
 
@@ -9,7 +9,7 @@ import SimpleWeightedGraphs:
 
 import Base: zero
 
-### LightGraphs interface
+### Graphs interface
 nv(g::AbstractSpatialGraph) = nv(g.graph)
 ne(g::AbstractSpatialGraph) = ne(g.graph)
 vertices(g::AbstractSpatialGraph) = vertices(g.graph)
@@ -22,13 +22,13 @@ inneighbors(g::AbstractSpatialGraph, v) = inneighbors(g.graph, v)
 outneighbors(g::AbstractSpatialGraph, v) = outneighbors(g.graph, v)
 is_directed(g::AbstractSpatialGraph) = is_directed(g.graph)
 function Base.zero(g::AbstractRasterGraph)
-    if g.graph isa SimpleGraph
-        SimpleRasterGraph(
+    if g.graph isa Graph
+        RasterGraph(
             zero(typeof(g.graph)),
             g.vertex_raster
         )
-    elseif g.graph isa SimpleDiGraph
-        SimpleRasterDiGraph(
+    elseif g.graph isa DiGraph
+        RasterDiGraph(
             zero(typeof(g.graph)),
             g.vertex_raster
         )

--- a/src/rastergraphs.jl
+++ b/src/rastergraphs.jl
@@ -119,14 +119,14 @@ function weightedrastergraph(
 end
 
 """
-    simplerastergraph(
+    RasterGraph(
         raster::GeoArray;
         directed::Bool = true,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false
     )
 
-Construct a `SimpleRasterGraph` or `SimpleRasterDiGraph` (if 
+Construct a `RasterGraph` or `RasterDiGraph` (if 
 `directed = true`) from a raster dataset.
 
 ## Parameters
@@ -161,7 +161,7 @@ connected. Note that when determining weights between diagonal neighbors, the
 increased distance between them (as compared to the distance between cardinal
 neighbors) is accounted for.
 """
-function simplerastergraph(
+function rastergraph(
         raster::GeoArray;
         condition::Function = is_data,
         directed::Bool = true,
@@ -177,9 +177,9 @@ function simplerastergraph(
     )
 
     if directed
-        sg = SimpleRasterDiGraph(g, v)
+        sg = RasterDiGraph(g, v)
     else
-        sg = SimpleRasterGraph(g, v)
+        sg = RasterGraph(g, v)
     end
 
     return sg
@@ -587,7 +587,7 @@ function make_raster_graph(
             )
         else
             n_nodes = max(maximum(sources), maximum(destinations))
-            g = SimpleDiGraph(
+            g = DiGraph(
                 sparse(sources, destinations, 1, n_nodes, n_nodes, combine)
             )
         end
@@ -601,7 +601,7 @@ function make_raster_graph(
             )
         else
             n_nodes = max(maximum(sources), maximum(destinations))
-            g = SimpleGraph(
+            g = Graph(
                 sparse(
                     vcat(sources, destinations),
                     vcat(destinations, sources),

--- a/src/rastergraphs.jl
+++ b/src/rastergraphs.jl
@@ -1,17 +1,17 @@
 """
-    make_vertex_raster(A::GeoArray)
+    make_vertex_raster(A::Raster)
 
 Constuct a vertex raster (a raster where the value of each pixel corresponds
-to its ID in a graph, and 0s correspond to NoData). Returns a GeoArray. This 
+to its ID in a graph, and 0s correspond to NoData). Returns a Raster. This 
 function is recommended for internal use only.
 
 ## Parameters
-`A`: The GeoArray from which a graph will be built, which is used as the
+`A`: The Raster from which a graph will be built, which is used as the
 reference for building the vertex raster. Pixels with NoData (`A.missingval`)
 are skipped (no vertex is assigned). Pixels with NoData will get a value of 0 in
 the vertex raster.
 """
-function make_vertex_raster(A::GeoData.GeoArray)
+function make_vertex_raster(A::Raster)
     # Make an array of unique node identifiers
     nodemap = zeros(Int64, size(A.data))
     is_node = (A.data .!= A.missingval) .&
@@ -19,7 +19,7 @@ function make_vertex_raster(A::GeoData.GeoArray)
 
     nodemap[is_node] = 1:sum(is_node)
 
-    nodemap = GeoData.GeoArray(nodemap, dims(A))
+    nodemap = Raster(nodemap, dims(A))
 
     nodemap
 end
@@ -27,9 +27,9 @@ end
 
 """
     weightedrastergraph(
-        weight_raster::GeoArray;
+        weight_raster::Raster;
         directed::Bool = false,
-        condition_raster::GeoArray = weight_raster,
+        condition_raster::Raster = weight_raster,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
         connect_using_avg_weights::Bool = true
@@ -42,7 +42,7 @@ on vertices, edge weights are calculated as the average of the weights for each
 vertex.
 
 ## Parameters
-`weight_raster`: A GeoData.GeoArray contained values that, where applicable 
+`weight_raster`: A Rasters.Raster contained values that, where applicable 
 based on other arguments, determines which pixels to connect and the edge 
 weights between pixels. Any pixel in `weight_raster` with a value not equal to 
 `weight_raster.missingval` will be assigned a vertex in the graph (corresponding
@@ -90,9 +90,9 @@ neighbors) of the weights  in `weight_raster` is used.
 
 """
 function weightedrastergraph(
-        weight_raster::GeoArray;
+        weight_raster::Raster;
         directed::Bool = false,
-        condition_raster::GeoArray = weight_raster,
+        condition_raster::Raster = weight_raster,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
         connect_using_avg_weights::Bool = true
@@ -120,7 +120,7 @@ end
 
 """
     RasterGraph(
-        raster::GeoArray;
+        raster::Raster;
         directed::Bool = true,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false
@@ -130,7 +130,7 @@ Construct a `RasterGraph` or `RasterDiGraph` (if
 `directed = true`) from a raster dataset.
 
 ## Parameters
-`raster`: A GeoData.GeoArray on which to base the graph. Any pixel in `raster` 
+`raster`: A Rasters.Raster on which to base the graph. Any pixel in `raster` 
 with a value not equal to `raster.missingval` will be assigned a vertex
 in the graph (corresponding to its centroid). The values in the raster can also
 be used to determine which vertices to connect. See `condition` below for more
@@ -162,7 +162,7 @@ increased distance between them (as compared to the distance between cardinal
 neighbors) is accounted for.
 """
 function rastergraph(
-        raster::GeoArray;
+        raster::Raster;
         condition::Function = is_data,
         directed::Bool = true,
         cardinal_neighbors_only::Bool = false,
@@ -187,10 +187,10 @@ end
 
 """
     make_weighted_raster_graph(
-        weight_raster::GeoArray,
-        vertex_raster::GeoArray;
+        weight_raster::Raster,
+        vertex_raster::Raster;
         directed::Bool = false,
-        condition_raster::GeoArray = weight_raster,
+        condition_raster::Raster = weight_raster,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
         connect_using_avg_weights::Bool = true,
@@ -206,13 +206,13 @@ vertex. Since edges are between rather than on vertices, edge weights are
 calculated as the average of the weights for each vertex being connected.
 
 ## Parameters
-`weight_raster`: A `GeoData.GeoArray` containing values that, where applicable 
+`weight_raster`: A `Rasters.Raster` containing values that, where applicable 
 based on other arguments, determine which pixels to connect and the edge 
 weights between pixels. Any pixel in `weight_raster` with a value not equal to 
 `weight_raster.missingval` will be assigned a vertex in the graph (corresponding
 to its centroid). 
 
-`vertex_raster`: A `GeoData.GeoArray` with integer values ranging from 1:n, 
+`vertex_raster`: A `Rasters.Raster` with integer values ranging from 1:n, 
 where n is the number of unique vertices in the graph. 
 
 ## Arguments
@@ -256,10 +256,10 @@ of vertices, how should the weight be chosen? Defaults to `min`. See the docs
 for `SparseArrays.sparse()` for more information.
 """
 function make_weighted_raster_graph(
-        weight_raster::GeoArray,
-        vertex_raster::GeoArray;
+        weight_raster::Raster,
+        vertex_raster::Raster;
         directed::Bool = false,
-        condition_raster::GeoArray = weight_raster,
+        condition_raster::Raster = weight_raster,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
         connect_using_avg_weights::Bool = true,
@@ -289,8 +289,8 @@ end
 
 """
     make_simple_raster_graph(
-        raster::GeoArray,
-        vertex_raster::GeoArray;
+        raster::Raster,
+        vertex_raster::Raster;
         directed::Bool = false,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
@@ -305,13 +305,13 @@ in the graph, and `raster` is used to construct the graph and determine which
 vertices to connect.
 
 ## Parameters
-`raster`: A GeoData.GeoArray on which to base the graph. Any pixel in `raster` 
+`raster`: A Rasters.Raster on which to base the graph. Any pixel in `raster` 
 with a value not equal to `raster.missingval` will be assigned a vertex
 in the graph (corresponding to its centroid). The values in the raster can also
 be used to determine which vertices to connect. See `condition` below for more
 information.
 
-`vertex_raster`: A `GeoData.GeoArray` with integer values ranging from 1:n, 
+`vertex_raster`: A `Rasters.Raster` with integer values ranging from 1:n, 
 where n is the number of unique vertices in the graph. 
 
 ## Arguments
@@ -355,8 +355,8 @@ of vertices, how should the weight be chosen? Defaults to `min`. See the docs
 for `SparseArrays.sparse()` for more information.
 """
 function make_simple_raster_graph(
-        raster::GeoArray,
-        vertex_raster::GeoArray;
+        raster::Raster,
+        vertex_raster::Raster;
         directed::Bool = false,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
@@ -378,11 +378,11 @@ end
 
 
 function make_raster_graph(
-        raster::GeoArray,
-        vertex_raster::GeoArray;
+        raster::Raster,
+        vertex_raster::Raster;
         directed::Bool = false,
         weighted::Bool = true,
-        condition_raster::GeoArray = raster,
+        condition_raster::Raster = raster,
         condition::Function = is_data,
         cardinal_neighbors_only::Bool = false,
         connect_using_avg_weights::Bool = true,
@@ -410,7 +410,7 @@ function make_raster_graph(
     # Add the edges
     # Only need to do neighbors down or to the right for undirected graphs
     # because edge additions will be redundant.
-    # Cardinal directions are in quotes since sometimes GeoArray are permuted
+    # Cardinal directions are in quotes since sometimes Raster are permuted
     # such that the top row doesn't necessarily correspond to the northern-most
     # pixels
     for row in 1:dims[1]

--- a/src/show.jl
+++ b/src/show.jl
@@ -12,8 +12,8 @@ function show(io::IO, g::AbstractRasterGraph)
     )
     printstyled(" with dimensions:\n", color=:light_black)
 
-    x_dim = dims(g.vertex_raster, XDim)
-    y_dim = dims(g.vertex_raster, YDim)
+    x_dim = dims(g.vertex_raster, X)
+    y_dim = dims(g.vertex_raster, Y)
     printstyled("    X", color=:cyan)
     print(
         ": range($(minimum(x_dim)), $(maximum(x_dim)), step=$(x_dim.val[2] - x_dim.val[1]))\n"

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -42,21 +42,21 @@ mutable struct WeightedRasterDiGraph{T<:Integer, U<:Real} <: AbstractRasterGraph
 end
 
 """
-    SimpleRasterGraph{T}
+    RasterGraph{T}
 
 A composite type for a spatially referenced graph. Vertices are spatially referenced based on a raster.
 """
-mutable struct SimpleRasterGraph{T<:Integer} <: AbstractRasterGraph{T}
-    graph::SimpleGraph{T} # A SimpleGraph
+mutable struct RasterGraph{T<:Integer} <: AbstractRasterGraph{T}
+    graph::Graph{T} # A Graph
     vertex_raster::GeoArray # A GeoArray raster, where a pixel's value denotes its vertex ID in the graph
 end
 
 """
-    SimpleRasterDiGraph{T}
+    RasterDiGraph{T}
 
 A composite type for a spatially referenced directed graph. Vertices are spatially referenced based on a raster.
 """
-mutable struct SimpleRasterDiGraph{T<:Integer} <: AbstractRasterGraph{T}
-    graph::SimpleDiGraph{T} # A SimpleDiGraph
+mutable struct RasterDiGraph{T<:Integer} <: AbstractRasterGraph{T}
+    graph::DiGraph{T} # A DiGraph
     vertex_raster::GeoArray # A GeoArray raster, where a pixel's value denotes its vertex ID in the graph
 end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -18,7 +18,7 @@ An abstract type representing a spatially referenced graph, with graph vertices 
 An AbstractRasterGraph must contain the following fields:
 
 - `graph::AbstractGraph`
-- `vertex_raster::GeoArray`
+- `vertex_raster::Raster`
 """
 abstract type AbstractRasterGraph{T} <: AbstractSpatialGraph{T} end
 
@@ -29,7 +29,7 @@ A composite type for a spatially referenced weighted graph. Vertices are spatial
 """
 mutable struct WeightedRasterGraph{T<:Integer, U<:Real} <: AbstractRasterGraph{T}
     graph::SimpleWeightedGraph{T, U} # a SimpleWeightedGraph with edge weights
-    vertex_raster::GeoArray # A GeoArray raster, where a pixel's value denotes its vertex ID in the graph
+    vertex_raster::Raster # A Raster raster, where a pixel's value denotes its vertex ID in the graph
 end
 """
     WeightedRasterDiGraph{T}
@@ -38,7 +38,7 @@ A composite type for a spatially referenced, weighted, directed graph. Vertices 
 """
 mutable struct WeightedRasterDiGraph{T<:Integer, U<:Real} <: AbstractRasterGraph{T}
     graph::SimpleWeightedDiGraph{T, U} # a SimpleWeightedDiGraph with edge weights
-    vertex_raster::GeoArray # A GeoArray raster, where a pixel's value denotes its vertex ID in the graph
+    vertex_raster::Raster # A Raster raster, where a pixel's value denotes its vertex ID in the graph
 end
 
 """
@@ -48,7 +48,7 @@ A composite type for a spatially referenced graph. Vertices are spatially refere
 """
 mutable struct RasterGraph{T<:Integer} <: AbstractRasterGraph{T}
     graph::Graph{T} # A Graph
-    vertex_raster::GeoArray # A GeoArray raster, where a pixel's value denotes its vertex ID in the graph
+    vertex_raster::Raster # A Raster raster, where a pixel's value denotes its vertex ID in the graph
 end
 
 """
@@ -58,5 +58,5 @@ A composite type for a spatially referenced directed graph. Vertices are spatial
 """
 mutable struct RasterDiGraph{T<:Integer} <: AbstractRasterGraph{T}
     graph::DiGraph{T} # A DiGraph
-    vertex_raster::GeoArray # A GeoArray raster, where a pixel's value denotes its vertex ID in the graph
+    vertex_raster::Raster # A Raster raster, where a pixel's value denotes its vertex ID in the graph
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,7 @@
     is_data(a::Number, b::Number)
 
 This function is the default used for deciding whether to connect two neighbors
-in a GeoArray when constructing a graph. It always returns `true`, so all
+in a Raster when constructing a graph. It always returns `true`, so all
 neighbors will be connected
 
 Returns `true`
@@ -22,7 +22,7 @@ res_cardinal_avg(x, y) = (x + y) / 2
 res_diagonal_avg(x, y) = ((x + y) * √2) / 2
 
 
-# function get_dims(A::GeoData.GeoArray)
+# function get_dims(A::Rasters.Raster)
 #     y_first = dims(mytif)[1] isa XDim
 #     first_dim_type = y_first ? YDim : XDim
 #     second_dim_type = y_first ? XDim : YDim

--- a/test/graph_interface.jl
+++ b/test/graph_interface.jl
@@ -1,4 +1,4 @@
-using SpatialGraphs, Test, GeoData, Graphs, SimpleWeightedGraphs
+using SpatialGraphs, Test, Rasters, Graphs, SimpleWeightedGraphs
 ## This script tests methods for the LightGraph interface that aren't already 
 ## used in other tests
 
@@ -8,7 +8,7 @@ x = X(1:4)
 y = Y(1:3)
 band = Band(1:1)
 
-weight_raster = GeoArray(A_array, (y, x, band), missingval = -9999)
+weight_raster = Raster(A_array, (y, x, band), missingval = -9999)
 rasgraph = weightedrastergraph(weight_raster)
 
 @test nv(rasgraph) == maximum(rasgraph.vertex_raster)

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -1,4 +1,4 @@
-using SpatialGraphs, Test, GeoData, LightGraphs, SimpleWeightedGraphs
+using SpatialGraphs, Test, GeoData, Graphs, SimpleWeightedGraphs
 ## This script tests methods for the LightGraph interface that aren't already 
 ## used in other tests
 

--- a/test/rasterdigraphs.jl
+++ b/test/rasterdigraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using Rasters, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 
 condition_array = Array{Float64}(undef, (3, 4, 1))
 condition_array[:,:,:] = [1, 0.5, 5, 2, 4, 8, 5, -9999, 2, 3, 6, 7]
@@ -7,7 +7,7 @@ x = X(1:4)
 y = Y(1:3)
 band = Band(1:1)
 
-condition_raster = GeoArray(condition_array, (y, x, band), missingval = -9999)
+condition_raster = Raster(condition_array, (y, x, band), missingval = -9999)
 
 compare = <
 rasgraph = rastergraph(

--- a/test/rasterdigraphs.jl
+++ b/test/rasterdigraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, LightGraphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 
 condition_array = Array{Float64}(undef, (3, 4, 1))
 condition_array[:,:,:] = [1, 0.5, 5, 2, 4, 8, 5, -9999, 2, 3, 6, 7]
@@ -10,7 +10,7 @@ band = Band(1:1)
 condition_raster = GeoArray(condition_array, (y, x, band), missingval = -9999)
 
 compare = <
-rasgraph = simplerastergraph(
+rasgraph = rastergraph(
     condition_raster,
     directed = true,
     condition = compare

--- a/test/rastergraphs.jl
+++ b/test/rastergraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using Rasters, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 
 array = Array{Int}(undef, (3, 4, 1))
 array[:,:,:] = [1, 1, 1, 1, 2, 2, 2, -9999, 2, 3, 3, 3]
@@ -7,7 +7,7 @@ x = X(1:4)
 y = Y(1:3)
 band = Band(1:1)
 
-raster = GeoArray(array, (y, x, band), missingval = -9999)
+raster = Raster(array, (y, x, band), missingval = -9999)
 
 compare = ==
 rasgraph = rastergraph(

--- a/test/rastergraphs.jl
+++ b/test/rastergraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, LightGraphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 
 array = Array{Int}(undef, (3, 4, 1))
 array[:,:,:] = [1, 1, 1, 1, 2, 2, 2, -9999, 2, 3, 3, 3]
@@ -10,7 +10,7 @@ band = Band(1:1)
 raster = GeoArray(array, (y, x, band), missingval = -9999)
 
 compare = ==
-rasgraph = simplerastergraph(
+rasgraph = rastergraph(
     raster,
     directed = false,
     condition = compare

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
-using GeoData, LightGraphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 
 @testset "Simple Raster Graph Construction" begin
-    include("simplerastergraphs.jl")
+    include("rastergraphs.jl")
 end
 
 @testset "Weighted Raster Graph Construction" begin
@@ -9,14 +9,14 @@ end
 end
 
 @testset "Simple Raster DiGraph Construction" begin
-    include("simplerasterdigraphs.jl")
+    include("rasterdigraphs.jl")
 end
 
 @testset "Weighted Raster DiGraph Construction" begin
     include("weightedrasterdigraphs.jl")
 end
 
-@testset "LightGraphs Interface" begin
+@testset "Graphs Interface" begin
     include("lg_interface.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using Rasters, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 
 @testset "Simple Raster Graph Construction" begin
     include("rastergraphs.jl")
@@ -17,7 +17,7 @@ end
 end
 
 @testset "Graphs Interface" begin
-    include("lg_interface.jl")
+    include("graph_interface.jl")
 end
 
 printstyled("Checking that Base.show works...\n", bold = true)
@@ -28,7 +28,7 @@ x = X(1:4)
 y = Y(1:3)
 band = Band(1:1)
 
-weight_raster = GeoArray(A_array, (y, x, band), missingval = -9999)
+weight_raster = Raster(A_array, (y, x, band), missingval = -9999)
 rasgraph = weightedrastergraph(weight_raster)
 show(rasgraph);print("\n")
 

--- a/test/weightedrasterdigraphs.jl
+++ b/test/weightedrasterdigraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, LightGraphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 A_array = Array{Float64}(undef, (3, 4, 1))
 A_array[:,:,:] = [1, 3, 2, 0.5, 10, 8, 5, -9999, 3, 1, 2, 6]
 

--- a/test/weightedrasterdigraphs.jl
+++ b/test/weightedrasterdigraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using Rasters, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 A_array = Array{Float64}(undef, (3, 4, 1))
 A_array[:,:,:] = [1, 3, 2, 0.5, 10, 8, 5, -9999, 3, 1, 2, 6]
 
@@ -9,8 +9,8 @@ x = X(1:4)
 y = Y(1:3)
 band = Band(1:1)
 
-weight_raster = GeoArray(A_array, (y, x, band), missingval = -9999)
-condition_raster = GeoArray(condition_array, (y, x, band), missingval = -9999)
+weight_raster = Raster(A_array, (y, x, band), missingval = -9999)
+condition_raster = Raster(condition_array, (y, x, band), missingval = -9999)
 
 compare = <
 rasgraph = weightedrastergraph(

--- a/test/weightedrastergraphs.jl
+++ b/test/weightedrastergraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using Rasters, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 A_array = Array{Float64}(undef, (3, 4, 1))
 A_array[:,:,:] = [1, 3, 2, 0.5, 10, 8, 5, -9999, 3, 1, 2, 6]
 
@@ -6,8 +6,8 @@ x = X(1:4)
 y = Y(1:3)
 band = Band(1:1)
 
-weight_raster = GeoArray(A_array, (y, x, band), missingval = -9999)
-weight_raster2d = GeoArray(A_array[:, :, 1], (y, x), missingval = -9999)
+weight_raster = Raster(A_array, (y, x, band), missingval = -9999)
+weight_raster2d = Raster(A_array[:, :, 1], (y, x), missingval = -9999)
 rasgraph2d = weightedrastergraph(
     weight_raster2d,
     connect_using_avg_weights = false

--- a/test/weightedrastergraphs.jl
+++ b/test/weightedrastergraphs.jl
@@ -1,4 +1,4 @@
-using GeoData, LightGraphs, SimpleWeightedGraphs, SpatialGraphs, Test
+using GeoData, Graphs, SimpleWeightedGraphs, SpatialGraphs, Test
 A_array = Array{Float64}(undef, (3, 4, 1))
 A_array[:,:,:] = [1, 3, 2, 0.5, 10, 8, 5, -9999, 3, 1, 2, 6]
 


### PR DESCRIPTION
Straightforward PR -- updated from LightGraphs to Graphs. Move from GeoData to Rasters. A couple of type names were also changed:
- `SimpleRasterGraph` => `RasterGraph`
- `SimpleRasterDiGraph` => `RasterDiGraph`