### PR TITLE
Revert "fix graphs interface for weighted graphs"

### DIFF
--- a/src/graph_interface.jl
+++ b/src/graph_interface.jl
@@ -5,99 +5,22 @@ import Graphs:
     inneighbors, outneighbors, is_directed, add_edge!
 
 import SimpleWeightedGraphs:
-    add_edge!, get_weight, add_vertex!
+    add_edge!, get_weight, add_vertex!, vertices
 
 import Base: zero
 
 ### Graphs interface
-function nv(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.nv(g.graph)
-    else
-        nv(g.graph)
-    end
-end
-
-function ne(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.ne(g.graph)
-    else
-        ne(g.graph)
-    end
-end
-
-function vertices(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.vertices(g.graph)
-    else
-        vertices(g.graph)
-    end
-end
-
-function edges(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.edges(g.graph)
-    else
-        edges(g.graph)
-    end
-end
-
-function eltype(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.eltype(g.graph)
-    else
-        eltype(g.graph)
-    end
-end
-
-function edgetype(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.edgetype(g.graph)
-    else
-        edgetype(g.graph)
-    end
-end
-
-function has_edge(g::AbstractSpatialGraph, s, d)
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.has_edge(g.graph, s, d)
-    else
-        has_edge(g.graph, s, d)
-    end    
-end
-
-function has_vertex(g::AbstractSpatialGraph, v)
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.has_vertex(g.graph, v)
-    else
-        has_vertex(g.graph, v)
-    end    
-end
-
-function inneighbors(g::AbstractSpatialGraph, v)
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.inneighbors(g.graph, v)
-    else
-        inneighbors(g.graph, v)
-    end    
-end
-
-function outneighbors(g::AbstractSpatialGraph, v)
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.outneighbors(g.graph, v)
-    else
-        outneighbors(g.graph, v)
-    end    
-end
-
-function is_directed(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.is_directed(g.graph)
-    else
-        is_directed(g.graph)
-    end
-end
-
+nv(g::AbstractSpatialGraph) = nv(g.graph)
+ne(g::AbstractSpatialGraph) = ne(g.graph)
+vertices(g::AbstractSpatialGraph) = vertices(g.graph)
+edges(g::AbstractSpatialGraph) = edges(g.graph)
+eltype(g::AbstractSpatialGraph) = eltype(g.graph)
+edgetype(g::AbstractSpatialGraph) = edgetype(g.graph)
+has_edge(g::AbstractSpatialGraph, s, d) = has_edge(g.graph, s, d)
+has_vertex(g::AbstractSpatialGraph, v) = has_vertex(g.graph, v)
+inneighbors(g::AbstractSpatialGraph, v) = inneighbors(g.graph, v)
+outneighbors(g::AbstractSpatialGraph, v) = outneighbors(g.graph, v)
+is_directed(g::AbstractSpatialGraph) = is_directed(g.graph)
 function Base.zero(g::AbstractRasterGraph)
     if g.graph isa Graph
         RasterGraph(
@@ -121,22 +44,8 @@ function Base.zero(g::AbstractRasterGraph)
         )
     end
 end
-
-function add_edge!(g::AbstractSpatialGraph, a::Integer, b::Integer, c::Number)
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.add_edge!(g.graph, a, b, c)
-    else
-        add_edge!(g.graph, a, b, c)
-    end
-end
-
-function add_vertex!(g::AbstractSpatialGraph) 
-    if typeof(g.graph) <: Union{SimpleWeightedGraph, SimpleWeightedDiGraph}
-        SimpleWeightedGraphs.add_vertex!(g.graph)
-    else
-        add_vertex!(g.graph)
-    end
-end
+add_edge!(g::AbstractSpatialGraph, a::Integer, b::Integer, c::Number) = add_edge!(g.graph, a, b, c)
+add_vertex!(g::AbstractSpatialGraph) = add_vertex!(g.graph)
 
 ### SimpleWeightedGraphs
 get_weight(g::WeightedRasterGraph, a::Integer, b::Integer) = get_weight(g.graph, a, b)


### PR DESCRIPTION
Reverts Circuitscape/SpatialGraphs.jl#6. That was a unneeded workaround. I just needed to tighten the version requirements for SimpleWeightedGraphs