### PR TITLE
handle "habitat patches" in which a vertex takes up more than one pixel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpatialGraphs"
 uuid = "c8109be6-b162-4503-8829-8b6b29b93f50"
 authors = ["Vincent A. Landau <vincent@csp-inc.org>"]
-version = "0.0.2"
+version = "0.1.1"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpatialGraphs"
 uuid = "c8109be6-b162-4503-8829-8b6b29b93f50"
 authors = ["Vincent A. Landau <vincent@csp-inc.org>"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/docs/src/userguide.md
+++ b/docs/src/userguide.md
@@ -22,3 +22,17 @@ make_simple_raster_graph
 weightedrastergraph
 make_weighted_raster_graph
 ```
+
+### Making vertex rasters
+In SpatialGraphs.jl, vertex rasters serve as the spatial reference for the 
+vertices in a graph. SpatialGraphs.jl provides functions to generate these
+rasters. Often, it is done internally and the end user doesn't need to use these
+functions, but there are some cases where it will be necessary. For example, it 
+is often the case that a user may want a single graph vertex to occupy multiple
+pixels in space (e.g. when modeling habitat connectivity between two
+protected areas). SpatialGraphs.jl enables this by offering a method for the 
+`make_vertex_raster` function (below) that accepts a raster
+representing these patches as an argument.
+```@docs
+make_vertex_raster
+```

--- a/src/SpatialGraphs.jl
+++ b/src/SpatialGraphs.jl
@@ -14,6 +14,6 @@ export AbstractSpatialGraph, AbstractRasterGraph, RasterGraph,
 
 ## Raster graph
 export make_weighted_raster_graph, weightedrastergraph,
-    make_simple_raster_graph, rastergraph
+    make_simple_raster_graph, rastergraph, make_vertex_raster
 
 end # module

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -1,0 +1,47 @@
+using Rasters, SpatialGraphs, Test, Graphs, SimpleWeightedGraphs
+
+resistance = [
+    1. 2.5 6 0.2;
+    5 6 12 1;
+    0.5 3 7 4;
+    11 0.5 9 -9999
+]
+
+res = Raster(
+    reshape(resistance, (size(resistance)..., 1)),
+    missingval=-9999,
+    dims=(X(1:4), Y(1:4), Band(1:1))
+)
+
+patches = [
+    1 1 0 3;
+    0 0 0 3;
+    0 0 0 0;
+    0 2 2 0
+]
+
+pat = Raster(
+    reshape(patches, (size(patches)..., 1)),
+    missingval=-9999,
+    dims=(X(1:4), Y(1:4), Band(1:1))
+)
+
+vertex_raster = make_vertex_raster(res, pat)
+
+# Check that patches have proper vertex ID
+for i in 1:maximum(pat)
+   @test all(vertex_raster[pat .== i] .== i)
+end
+
+@test sort(unique(vertex_raster[vertex_raster .> maximum(pat)])) ==
+    (maximum(pat) + 1):(maximum(pat) + length(res[(pat .== 0) .& (res .!= res.missingval)]))
+
+## Make sure that a graph can be successfully created from a the vertex raster
+g = WeightedRasterGraph(make_weighted_raster_graph(res, vertex_raster), vertex_raster)
+
+# Test that a few random weights are correct, assumes that defaults were used
+# in make_weighted_raster_graph above, particularly that combine = min and
+# connect_using_avg_weights = true. THESE ARE HARD CODED. Changes to res or pat
+# above will result in failed tests.
+@test get_weight(g.graph, 1, 4) == 3 # minimum of the mean resistances between both vertices labeled 1 and vertex labeled 4
+@test get_weight(g.graph, 7, 11) == SpatialGraphs.res_diagonal_avg(res[vertex_raster .== 7], res[vertex_raster .== 11])[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ end
     include("graph_interface.jl")
 end
 
+@testset "Graphs with patches" begin
+    include("patches.jl")
+end
+
 printstyled("Checking that Base.show works...\n", bold = true)
 
 A_array = Array{Float64}(undef, (3, 4, 1))


### PR DESCRIPTION
This is necessary for being able to measure/map connectivity between patches that are considered to be a single vertex in a graph. Only a simple change was needed: add a method to `make_vertex_raster()` that accepts a second Raster defining the patches (see the docstring for the function for more details. I added corresponding tests to make sure things worked properly following this change. Sometime soon, I'll update the example in the docs to include this functionality and demo how use it properly, the can issue a new release.