### PR TITLE
Bump Rasters.jl compat requirement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Graphs = "1.4"
-Rasters = "0.1.1"
+Rasters = "0.1.1, 0.2, 0.3, 0.4, 0.5"
 SimpleWeightedGraphs = "1.2"
 julia = "1.6"


### PR DESCRIPTION
I came across this package in a pkgeval run on Julia Base. The Rasters restriction here prevents packages that use this one to fetch updates from other packages. Specifically, MetapopulationDynamics.jl is affected. If this is working, could you please release the v0.1.1 (it's already marked as such)?